### PR TITLE
Update GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -28,6 +28,9 @@
 - Determine *Team Members* of their respecitve repository
 - Organize release process for their subproject
 
+### Current Teams
+- [Kokkos Kernels Core](https://github.com/orgs/kokkos/teams/kokkoskernelscore)
+
 # Team Members
 
 ### Role
@@ -35,3 +38,6 @@
 - Develop code
 - Review Pull Requests
 - Maintain documentation
+
+### Current Teams
+- [Kokkos Kernels](https://github.com/orgs/kokkos/teams/kokkoskernels)


### PR DESCRIPTION
Starting to populate this a bit with github teams that reflect the roles in the Kokkos Kernels repo. We should clean-up the teams first but that at least gets us started? We might want to change the name of these teams as well to have something uniform as discussed in the leads meeting.